### PR TITLE
replaced run-sehll-command

### DIFF
--- a/src/git.lisp
+++ b/src/git.lisp
@@ -10,20 +10,20 @@
 
 (defun git-init ()
   "Initialize a git repo."
-  (run-shell-command "git init"))
+  (run-program "git init"))
 
 (defun git-remove ()
   "Remove the git repo of the current working directory."
-  (run-shell-command "rm -r .git < /usr/bin/yes")
-  (run-shell-command "rm -r quotes"))
+  (run-program "rm -r .git < /usr/bin/yes")
+  (run-program "rm -r quotes"))
 
 (defun git-commit (date)
   "Create a commit using the date and a random commit message."
-  (run-shell-command "fortune >> quotes")
+  (run-program "fortune >> quotes")
 
-  (run-shell-command "git add quotes")
+  (run-program "git add quotes")
 
-  (run-shell-command
+  (run-program
    (concatenate 'string
                 (format nil
                         "git commit --date=\"~A\" -m \"~A\""

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -1,6 +1,6 @@
 (defpackage :trolling-success
   (:use :cl :local-time)
   (:nicknames "SaS")
-  (:import-from :asdf :run-shell-command)
+  (:import-from :uiop :run-program)
   (:export
    #:write-to-canvas))


### PR DESCRIPTION
I replaced from asdf:run-shell-command to uiop:run-program.
Because, this kind of warning comes out.
```common-lisp
WARNING:
   DEPRECATED-FUNCTION-STYLE-WARNING: Using deprecated function ASDF/BACKWARD-INTERFACE:RUN-SHELL-COMMAND -- please update your code to use a newer API.
The docstring for this function says:
PLEASE DO NOT USE. This function is not just DEPRECATED, but also dysfunctional.
Please use UIOP:RUN-PROGRAM instead.
```